### PR TITLE
HM-157/v2[DetailsProperty][Bug]Scroll to top

### DIFF
--- a/test-app/src/UI/ScrollToTopOnMount.jsx
+++ b/test-app/src/UI/ScrollToTopOnMount.jsx
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+
+
+function ScrollToTopOnMount() {
+    useEffect(() => {
+      window.scrollTo(0, 0);
+    }, []);
+  
+    return null;
+  }
+
+  export default ScrollToTopOnMount;
+  

--- a/test-app/src/components/CatalogItems/PropertiesDetails/PropertiesDetails.jsx
+++ b/test-app/src/components/CatalogItems/PropertiesDetails/PropertiesDetails.jsx
@@ -17,6 +17,7 @@ import DetailsImages from './DetailsImages';
 // UI
 import { TextSkeleton } from '../../../UI/Skeletons';
 import { changeLikedProperties } from '../../../store/features/slices/likedProperties';
+import ScrollToTopOnMount from '../../../UI/ScrollToTopOnMount';
 
 // Util functions
 import { validationPropertyReportSchema } from '../../../util/validationSchema';
@@ -97,6 +98,7 @@ const PropertiesDetails = () => {
 
     return (
         <section className='relative m-4 mt-10'>
+            <ScrollToTopOnMount key={detailsId} />
             <h1 className='inline-block text-3xl font-semibold'>
                 {property?.numberOfRooms} апартамент за продажба, {property?.space} m<sup>2</sup>
             </h1>


### PR DESCRIPTION
Actual behavior:

When opening the details of a property that is further down on the property page, it shows the bottom of the property details page.

Expected behavior:

Always when opening property details, show the top of the property details page.