### PR TITLE
HM-159/v2[Admin][Bug]

### DIFF
--- a/test-app/src/components/AdminDashboard/Dashboard.jsx
+++ b/test-app/src/components/AdminDashboard/Dashboard.jsx
@@ -18,7 +18,7 @@ const Dashboard = () => {
 
     return (
         <div className=''>
-            <div className={`fixed z-[60] ${isOpen && 'rounded-e-xl bg-gray-200'}`}>
+            <div className={`fixed ${isOpen && 'z-[60] rounded-e-xl bg-gray-200'}`}>
                 <div className={`relative m-3  `}>
                     <button
                         onClick={() => setIsOpen((prev) => !prev)}


### PR DESCRIPTION
The invisible shadow of the admin panel button hides the property below it and prevents it from being clicked.